### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.1.0](https://github.com/tks18/finance-manager-backend/compare/v3.0.0...v3.1.0) (2023-08-17)
+
+
+### Bug Fixes 🛠
+
+* **models/insurance-master:** fix the cover period field date formats to ISO standard ([66271b9](https://github.com/tks18/finance-manager-backend/commit/66271b9edf5ae96aa2f36dd3ccc70a8386a123ac))
+
 ## [3.0.0](https://github.com/tks18/finance-manager-backend/compare/v2.8.0...v3.0.0) (2023-08-15)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-express-template",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-express-template",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@godaddy/terminus": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-manager-backend",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Backend for Personal Finance Manager made with Nodejs, Express & Typescript",
   "main": "src/app.ts",
   "scripts": {

--- a/src/models/master/other/insurances.model.ts
+++ b/src/models/master/other/insurances.model.ts
@@ -123,12 +123,6 @@ export function initInsuranceMaster(sequelize: Sequelize): void {
           const value = String(this.getDataValue('cover_period_start_date'));
           return DateTime.fromFormat(value, 'yyyy-LL-dd').toISODate();
         },
-        set(value: DateTime) {
-          this.setDataValue(
-            'cover_period_start_date',
-            value.toFormat('yyyy-LL-dd'),
-          );
-        },
       },
       cover_period_end_date: {
         allowNull: false,


### PR DESCRIPTION
## [3.1.0](https://github.com/tks18/finance-manager-backend/compare/v3.0.0...v3.1.0) (2023-08-17)


### Bug Fixes 🛠

* **models/insurance-master:** fix the cover period field date formats to ISO standard ([66271b9](https://github.com/tks18/finance-manager-backend/commit/66271b9edf5ae96aa2f36dd3ccc70a8386a123ac))